### PR TITLE
[FIX] Code injection using normal assignment

### DIFF
--- a/routes/colpost.js
+++ b/routes/colpost.js
@@ -74,7 +74,7 @@ module.exports = function(req, res, next){
 				case 'boolean':
 				case 'mixed':
 					try {
-						eval('value=' + req.body.value);
+						value = req.body.value;
 					} catch(err){
 						res.send({error: err.message});
 					}
@@ -95,7 +95,7 @@ module.exports = function(req, res, next){
 			});
 			break;
 		case 'deleteField':
-			eval('update = {$unset: {"' + req.body.key + '": ""}}');
+			update = {$unset: JSON.parse('{"' + req.body.key + '": ""}') };
 
 			col.update(query, update, function(err, r){
 				res.send({error: err && err.message, affected: r});
@@ -107,7 +107,7 @@ module.exports = function(req, res, next){
 			try{
 				let json = null;
 
-				eval('json = ' + req.body.json);
+				json = req.body.json;
 
 				if(!Object.keys(json).length)
 					return req.res.redirect(req.path);

--- a/routes/command.js
+++ b/routes/command.js
@@ -6,7 +6,7 @@ module.exports = function(req, res){
 	
 	var command;
 	
-	eval('command=' + req.body.command);
+	command = req.body.command;
 
 	var db = req.body.db ? req.mongoMng.useDb(req.body.db) : req.mongoMng.db;
 	

--- a/routes/db.js
+++ b/routes/db.js
@@ -300,7 +300,7 @@ class EMongo {
 			return {};
 
 		try {
-			eval('query=' + this.req.query.criteria.replace(/[\t\n\r]/g, ''));
+			query = this.req.query.criteria.replace(/[\t\n\r]/g, '');
 
 			//noinspection JSUnusedAssignment
 			return query || new Error('Invalid query');
@@ -323,7 +323,7 @@ class EMongo {
 			try {
 				let ret;
 
-				eval('ret=' + this.req.query.update.replace(/[\t\n\r]/g, ''));
+				ret = this.req.query.update.replace(/[\t\n\r]/g, '');
 
 				if(!ret)
 					return ko(new Error('Invalid update operators'));


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-mongui

### ⚙️ Description *

The `mongui` tool was vulnerable against `code injection` due to a `unsafe` usage of the `eval` function, which was processing `user-supplied` inputs.
The `eval` function (remember, **eval is evil**) was used to `assign` a value to different `variables` which were `declared` without being `initialized`.

### 💻 Technical Description *

Since the `eval` function could be simply removed and `variable` assignment can be done simply through the `=` operator, I used it. Note the datatypes were different, so I used also `JSON.parse` to process valid objects and then concatenate the `output` in a `non-JSON` formatted object, which was therefore not validated by `JSON.parse()` :smile:

### 🐛 Proof of Concept (PoC) *

No PoC provided

### 🔥 Proof of Fix (PoF) *

Using the fixed version it's impossible process/evaluate `user supplied` inputs

### 👍 User Acceptance Testing (UAT)

No issues should be present since I only changed the `assignment` process with the `=` operator